### PR TITLE
Fix npm start and add a dev command

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -8,4 +8,4 @@ require('babel-polyfill');
 require('babel-register');
 
 // Import the rest of our application.
-module.exports = require('../lib/app.js');
+module.exports = require('../src/app.js');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "lib/server.js",
   "scripts": {
     "build": "babel src --out-dir lib --ignore bin/ --copy-files",
-    "start": "node ./bin/www",
+    "dev": "node ./bin/www",
+    "start": "[ -d ./lib ] && node ./lib/app.js || echo 'Error: Directory `./lib` is missing.\nUse `npm run build` to build app for production.\nUse `npm run dev` for development.'",
     "test": "NODE_ENV=test mocha -R spec ./test/* --exit --require babel-polyfill --require babel-register",
     "lint": "eslint test/ src/",
     "prepublish": "npm run build"


### PR DESCRIPTION
npm start = production
npm run dev = development

Sortie si le build n'a pas été effectué :

```shell
$ npm start

> fi-example@0.0.3 start /home/huge/Workspaces/franceConnect/identity-provider-example
> [ -d ./lib ] && node ./lib/app.js || echo 'Error: Directory `./lib` is missing.
Use `npm run build` to build app for production.
Use `npm run dev` for development.'

Error: Directory `./lib` is missing.
Use `npm run build` to build app for production.
Use `npm run dev` for development.
```