### PR TITLE
[FCP-569] As a partner i want the identity provider login screen to display a default eidas level corresponding to the eidas level set by the service provider

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -30,8 +30,9 @@ export const mountRoutes = (app, provider) => {
       const notifications = messages[req.query.notification]
         ? [messages[req.query.notification]]
         : [];
-      const acr = req.session.infos.acr_values;
-
+ 
+      const acr = req.session.infos.acr_values ? req.session.infos.acr_values : '';
+ 
       if (error === 'login_required') {
         return res.render('sign-in', {
           notifications,

--- a/src/router.js
+++ b/src/router.js
@@ -30,9 +30,11 @@ export const mountRoutes = (app, provider) => {
       const notifications = messages[req.query.notification]
         ? [messages[req.query.notification]]
         : [];
- 
-      const acr = req.session.infos.acr_values ? req.session.infos.acr_values : '';
- 
+
+      const {
+        session: { info: { acr_values : acr } = {} }
+      } = req;
+
       if (error === 'login_required') {
         return res.render('sign-in', {
           notifications,

--- a/src/router.js
+++ b/src/router.js
@@ -32,7 +32,7 @@ export const mountRoutes = (app, provider) => {
         : [];
 
       const {
-        session: { info: { acr_values : acr } = {} }
+        session: { info: { acr_values: acr } = {} },
       } = req;
 
       if (error === 'login_required') {

--- a/src/router.js
+++ b/src/router.js
@@ -30,11 +30,13 @@ export const mountRoutes = (app, provider) => {
       const notifications = messages[req.query.notification]
         ? [messages[req.query.notification]]
         : [];
+      const acr = req.session.infos.acr_values;
 
       if (error === 'login_required') {
         return res.render('sign-in', {
           notifications,
           interactionId,
+          acr,
         });
       }
 

--- a/src/views/sign-in.ejs
+++ b/src/views/sign-in.ejs
@@ -25,9 +25,9 @@
         <div class="form__group">
             <label for="acr">Niveau eIDAS (à renvoyer à FC)*</label>
             <select class="form-control" required name="acr" placeholder="Niveau eIDAS (à renvoyer à FC)*">
-                <option value="eidas1" <%= locals.acr = 'eidas1' ? 'selected' : '' %>>Faible (eidas1)</option>
-                <option value="eidas2" <%= locals.acr = 'eidas2' ? 'selected' : '' %>>Substantiel (eidas2)</option>
-                <option value="eidas3" <%= locals.acr = 'eidas3' ? 'selected' : '' %>>Élevé (eidas3)</option>
+                <option value="eidas1" <%= !locals.acr || locals.acr && locals.acr == 'eidas1' ? 'selected' : '' %>>Faible (eidas1)</option>
+                <option value="eidas2" <%= locals.acr && locals.acr == 'eidas2' ? 'selected' : '' %>>Substantiel (eidas2)</option>
+                <option value="eidas3" <%= locals.acr && locals.acr == 'eidas3' ? 'selected' : '' %>>Élevé (eidas3)</option>
             </select>
             <p><strong><i>*Forcer le niveau eIDAS renvoyé par le Fournisseur d'Identité ne fonctionnera que si le Fournisseur de Service a précisé le paramètre "acr_values" dans l'appel à FranceConnect. Le cas échéant, le niveau faible (eidas1) sera renvoyé par FranceConnect.</i></strong></p>
         </div>

--- a/src/views/sign-in.ejs
+++ b/src/views/sign-in.ejs
@@ -25,9 +25,9 @@
         <div class="form__group">
             <label for="acr">Niveau eIDAS (à renvoyer à FC)*</label>
             <select class="form-control" required name="acr" placeholder="Niveau eIDAS (à renvoyer à FC)*">
-                <option value="eidas1" selected>Faible (eidas1)</option>
-                <option value="eidas2">Substantiel (eidas2)</option>
-                <option value="eidas3">Élevé (eidas3)</option>
+                <option value="eidas1" <%= locals.acr = 'eidas1' ? 'selected' : '' %>>Faible (eidas1)</option>
+                <option value="eidas2" <%= locals.acr = 'eidas2' ? 'selected' : '' %>>Substantiel (eidas2)</option>
+                <option value="eidas3" <%= locals.acr = 'eidas3' ? 'selected' : '' %>>Élevé (eidas3)</option>
             </select>
             <p><strong><i>*Forcer le niveau eIDAS renvoyé par le Fournisseur d'Identité ne fonctionnera que si le Fournisseur de Service a précisé le paramètre "acr_values" dans l'appel à FranceConnect. Le cas échéant, le niveau faible (eidas1) sera renvoyé par FranceConnect.</i></strong></p>
         </div>


### PR DESCRIPTION
inside router.ejs, on route get /interaction/:grant, adding a constant acr coming from req.session.info.acr_values, and passing to the render of sign-in.
Inside sign-in setting the default value of the dropdown to the value acr coming from the controller if exist, or to eidas1.
