### PR TITLE
Revert "[FCP-569] As a partner i want the identity provider login screen to display a default eidas level corresponding to the eidas level set by the service provider"

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -31,15 +31,10 @@ export const mountRoutes = (app, provider) => {
         ? [messages[req.query.notification]]
         : [];
 
-      const {
-        session: { info: { acr_values: acr } = {} },
-      } = req;
-
       if (error === 'login_required') {
         return res.render('sign-in', {
           notifications,
           interactionId,
-          acr,
         });
       }
 

--- a/src/views/sign-in.ejs
+++ b/src/views/sign-in.ejs
@@ -25,9 +25,9 @@
         <div class="form__group">
             <label for="acr">Niveau eIDAS (à renvoyer à FC)*</label>
             <select class="form-control" required name="acr" placeholder="Niveau eIDAS (à renvoyer à FC)*">
-                <option value="eidas1" <%= !locals.acr || locals.acr && locals.acr == 'eidas1' ? 'selected' : '' %>>Faible (eidas1)</option>
-                <option value="eidas2" <%= locals.acr && locals.acr == 'eidas2' ? 'selected' : '' %>>Substantiel (eidas2)</option>
-                <option value="eidas3" <%= locals.acr && locals.acr == 'eidas3' ? 'selected' : '' %>>Élevé (eidas3)</option>
+                <option value="eidas1" selected>Faible (eidas1)</option>
+                <option value="eidas2">Substantiel (eidas2)</option>
+                <option value="eidas3">Élevé (eidas3)</option>
             </select>
             <p><strong><i>*Forcer le niveau eIDAS renvoyé par le Fournisseur d'Identité ne fonctionnera que si le Fournisseur de Service a précisé le paramètre "acr_values" dans l'appel à FranceConnect. Le cas échéant, le niveau faible (eidas1) sera renvoyé par FranceConnect.</i></strong></p>
         </div>


### PR DESCRIPTION
Reverts france-connect/identity-provider-example#65