### PR TITLE
ajout aphp

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -64,4 +64,4 @@ id,identifiant        ,motDePasse,nomDeNaissance                                
 63,test_doublon1,123,CASA,,MILA,female,Testcas456@yopmail.com,123456789,1986-01-01,,75015,France,Paris,75015,10 rue de l'Opera
 64,test_doublon2,123,CASA,,MILA,female,Testcas678@yopmail.com,123456789,1972-06-26,,75018,France,Paris,75018,45 rue du Pasteur
 65 ,test_droits               ,123       ,DURAND                                              ,Fournier       ,Audrey      ,female,adurand@yopmail.com   ,0143356789,1978-02-15     ,75108                    ,99200              ,France     ,Paris       ,75109            ,20 avenue de Ségur
-
+65 ,test_aphp               ,123       ,HAAS                                              ,HAAS       ,pierre-etienne      ,pierre-etienne.haas@aphp.fr  ,0615794436,1979-07-01     ,60612                    ,99100              ,France     ,Paris       ,75109            ,20 avenue de Ségur


### PR DESCRIPTION
Nous essayons de limiter au maximum l'ajout d'identités dans le fichier [database.csv](database.csv) pour réduire les coûts de maintenance et limiter les risques de non conformité au RGPD.

Si vous avez modifié ce fichier, pouvez vous nous préciser ce qui vous a manqué dans les identités déjà présentes dans le fichier et en quoi vos identités résolvent le problème ?
