### PR TITLE
Update database.csv - Nouveaux cas pour le Casier Judiciaire National

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -85,5 +85,5 @@ id       ,identifiant                     ,motDePasse,nomDeNaissance            
 128,radnoncertif05_tech             ,123,BOUCHON A                                           ,         ,Dpi                       ,female,test@yopmail.com              ,123456789,1985-09-11     ,68022,99100,France     ,Paris       ,75107,20 avenue de Ségur
 129,radnoncertif06_tech             ,123,BOUCHONA                                            ,         ,Dpi                       ,male  ,test@yopmail.com              ,123456789,1982-11-06     ,93008,99109,France     ,Paris       ,75107,20 avenue de Ségur
 130,naissance_wallis_futuna,123,DUPONT,,JEAN,male,test@yopmail.com,0102030405,14/06/1972,98611,99100,France,Nantes,44317,20 avenue de Ségur
-131,carac_speciaux,123,DURANTéàèùòœæŒÆ,,JulieéàèùòœæŒÆ,female,test@yopmail.com,0102030405,14/06/1972,98611,99100,France,Nantes,44317,20 avenue de Ségur
-132,sans_prenom,123,MARTIN,,,female,test@yopmail.com,0102030405,14/06/1972,98611,99100,France,Nantes,44317,20 avenue de Ségur
+131,carac_speciaux,123,DURANTéàèùòœæŒÆ,,JulieéàèùòœæŒÆ,female,test@yopmail.com,0102030405,14/06/1972,2B002,99100,France,Nantes,44317,20 avenue de Ségur
+132,sans_prenom,123,MARTIN,,,female,test@yopmail.com,0102030405,14/06/1972,97601,99100,France,Nantes,44317,20 avenue de Ségur

--- a/database.csv
+++ b/database.csv
@@ -84,6 +84,6 @@ id       ,identifiant                     ,motDePasse,nomDeNaissance            
 127,radcertif04_tech                ,123,BOUCHON CLOVIS                                      ,         ,Fabien                    ,male  ,test@yopmail.com              ,123456789,1975-06-02     ,25104,99100,France     ,Paris       ,75107,20 avenue de Ségur
 128,radnoncertif05_tech             ,123,BOUCHON A                                           ,         ,Dpi                       ,female,test@yopmail.com              ,123456789,1985-09-11     ,68022,99100,France     ,Paris       ,75107,20 avenue de Ségur
 129,radnoncertif06_tech             ,123,BOUCHONA                                            ,         ,Dpi                       ,male  ,test@yopmail.com              ,123456789,1982-11-06     ,93008,99109,France     ,Paris       ,75107,20 avenue de Ségur
-130,naissance_wallis_futuna,123,DUPONT,,JEAN,male,test@yopmail.com,0102030405,14/06/1972,98611,99100,France,Nantes,44317,20 avenue de Ségur
-131,carac_speciaux,123,DURANTéàèùòœæŒÆ,,JulieéàèùòœæŒÆ,female,test@yopmail.com,0102030405,14/06/1972,2B002,99100,France,Nantes,44317,20 avenue de Ségur
-132,sans_prenom,123,MARTIN,,,female,test@yopmail.com,0102030405,14/06/1972,97601,99100,France,Nantes,44317,20 avenue de Ségur
+130,naissance_wallis_futuna,123,Fleury,,Fabien,male,ijujasa-5293@yopmail.com,0102030405,1972-06-14,98611,99100,France,Nantes,44317,20 avenue de Ségur
+131,carac_speciaux,123,DURANTéàèùòœæŒÆ,,JulieéàèùòœæŒÆ,female,test@yopmail.com,0102030405,1972-06-14,2B002,99100,France,Nantes,44317,20 avenue de Ségur
+132,sans_prenom,123,MARTIN,,,female,zalojummu-4690@yopmail.com,0102030405,1972-06-14,97601,99100,France,Nantes,44317,20 avenue de Ségur

--- a/database.csv
+++ b/database.csv
@@ -84,3 +84,6 @@ id       ,identifiant                     ,motDePasse,nomDeNaissance            
 127,radcertif04_tech                ,123,BOUCHON CLOVIS                                      ,         ,Fabien                    ,male  ,test@yopmail.com              ,123456789,1975-06-02     ,25104,99100,France     ,Paris       ,75107,20 avenue de Ségur
 128,radnoncertif05_tech             ,123,BOUCHON A                                           ,         ,Dpi                       ,female,test@yopmail.com              ,123456789,1985-09-11     ,68022,99100,France     ,Paris       ,75107,20 avenue de Ségur
 129,radnoncertif06_tech             ,123,BOUCHONA                                            ,         ,Dpi                       ,male  ,test@yopmail.com              ,123456789,1982-11-06     ,93008,99109,France     ,Paris       ,75107,20 avenue de Ségur
+130,naissance_wallis_futuna,123,DUPONT,JEAN,M,test@yopmail.com,102030405,14/06/1972,98600,99100,France,Nantes,44317,20 avenue de Ségur
+131,carac_speciaux,123,DURANTéàèùò&~#@œæŒÆ,,Julieéàèùò&~#@œæŒÆ,F,test@yopmail.com,102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur
+132,sans_prenom,123,MARTIN,,,F,test@yopmail.com,102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur

--- a/database.csv
+++ b/database.csv
@@ -84,6 +84,6 @@ id       ,identifiant                     ,motDePasse,nomDeNaissance            
 127,radcertif04_tech                ,123,BOUCHON CLOVIS                                      ,         ,Fabien                    ,male  ,test@yopmail.com              ,123456789,1975-06-02     ,25104,99100,France     ,Paris       ,75107,20 avenue de Ségur
 128,radnoncertif05_tech             ,123,BOUCHON A                                           ,         ,Dpi                       ,female,test@yopmail.com              ,123456789,1985-09-11     ,68022,99100,France     ,Paris       ,75107,20 avenue de Ségur
 129,radnoncertif06_tech             ,123,BOUCHONA                                            ,         ,Dpi                       ,male  ,test@yopmail.com              ,123456789,1982-11-06     ,93008,99109,France     ,Paris       ,75107,20 avenue de Ségur
-130,naissance_wallis_futuna,123,DUPONT,,JEAN,male,test@yopmail.com,0102030405,14/06/1972,98600,99100,France,Nantes,44317,20 avenue de Ségur
-131,carac_speciaux,123,DURANTéàèùòœæŒÆ,,JulieéàèùòœæŒÆ,female,test@yopmail.com,0102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur
-132,sans_prenom,123,MARTIN,,,female,test@yopmail.com,0102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur
+130,naissance_wallis_futuna,123,DUPONT,,JEAN,male,test@yopmail.com,0102030405,14/06/1972,98611,99100,France,Nantes,44317,20 avenue de Ségur
+131,carac_speciaux,123,DURANTéàèùòœæŒÆ,,JulieéàèùòœæŒÆ,female,test@yopmail.com,0102030405,14/06/1972,98611,99100,France,Nantes,44317,20 avenue de Ségur
+132,sans_prenom,123,MARTIN,,,female,test@yopmail.com,0102030405,14/06/1972,98611,99100,France,Nantes,44317,20 avenue de Ségur

--- a/database.csv
+++ b/database.csv
@@ -84,6 +84,6 @@ id       ,identifiant                     ,motDePasse,nomDeNaissance            
 127,radcertif04_tech                ,123,BOUCHON CLOVIS                                      ,         ,Fabien                    ,male  ,test@yopmail.com              ,123456789,1975-06-02     ,25104,99100,France     ,Paris       ,75107,20 avenue de Ségur
 128,radnoncertif05_tech             ,123,BOUCHON A                                           ,         ,Dpi                       ,female,test@yopmail.com              ,123456789,1985-09-11     ,68022,99100,France     ,Paris       ,75107,20 avenue de Ségur
 129,radnoncertif06_tech             ,123,BOUCHONA                                            ,         ,Dpi                       ,male  ,test@yopmail.com              ,123456789,1982-11-06     ,93008,99109,France     ,Paris       ,75107,20 avenue de Ségur
-130,naissance_wallis_futuna,123,DUPONT,,JEAN,M,test@yopmail.com,102030405,14/06/1972,98600,99100,France,Nantes,44317,20 avenue de Ségur
-131,carac_speciaux,123,DURANTéàèùò&~#@œæŒÆ,,Julieéàèùò&~#@œæŒÆ,F,test@yopmail.com,102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur
-132,sans_prenom,123,MARTIN,,,F,test@yopmail.com,102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur
+130,naissance_wallis_futuna,123,DUPONT,,JEAN,male,test@yopmail.com,0102030405,14/06/1972,98600,99100,France,Nantes,44317,20 avenue de Ségur
+131,carac_speciaux,123,DURANTéàèùò&~#@œæŒÆ,,Julieéàèùò&~#@œæŒÆ,female,test@yopmail.com,0102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur
+132,sans_prenom,123,MARTIN,,,female,test@yopmail.com,0102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur

--- a/database.csv
+++ b/database.csv
@@ -84,6 +84,6 @@ id       ,identifiant                     ,motDePasse,nomDeNaissance            
 127,radcertif04_tech                ,123,BOUCHON CLOVIS                                      ,         ,Fabien                    ,male  ,test@yopmail.com              ,123456789,1975-06-02     ,25104,99100,France     ,Paris       ,75107,20 avenue de Ségur
 128,radnoncertif05_tech             ,123,BOUCHON A                                           ,         ,Dpi                       ,female,test@yopmail.com              ,123456789,1985-09-11     ,68022,99100,France     ,Paris       ,75107,20 avenue de Ségur
 129,radnoncertif06_tech             ,123,BOUCHONA                                            ,         ,Dpi                       ,male  ,test@yopmail.com              ,123456789,1982-11-06     ,93008,99109,France     ,Paris       ,75107,20 avenue de Ségur
-130,naissance_wallis_futuna,123,DUPONT,JEAN,M,test@yopmail.com,102030405,14/06/1972,98600,99100,France,Nantes,44317,20 avenue de Ségur
+130,naissance_wallis_futuna,123,DUPONT,,JEAN,M,test@yopmail.com,102030405,14/06/1972,98600,99100,France,Nantes,44317,20 avenue de Ségur
 131,carac_speciaux,123,DURANTéàèùò&~#@œæŒÆ,,Julieéàèùò&~#@œæŒÆ,F,test@yopmail.com,102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur
 132,sans_prenom,123,MARTIN,,,F,test@yopmail.com,102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur

--- a/database.csv
+++ b/database.csv
@@ -85,5 +85,5 @@ id       ,identifiant                     ,motDePasse,nomDeNaissance            
 128,radnoncertif05_tech             ,123,BOUCHON A                                           ,         ,Dpi                       ,female,test@yopmail.com              ,123456789,1985-09-11     ,68022,99100,France     ,Paris       ,75107,20 avenue de Ségur
 129,radnoncertif06_tech             ,123,BOUCHONA                                            ,         ,Dpi                       ,male  ,test@yopmail.com              ,123456789,1982-11-06     ,93008,99109,France     ,Paris       ,75107,20 avenue de Ségur
 130,naissance_wallis_futuna,123,DUPONT,,JEAN,male,test@yopmail.com,0102030405,14/06/1972,98600,99100,France,Nantes,44317,20 avenue de Ségur
-131,carac_speciaux,123,DURANTéàèùò&~#@œæŒÆ,,Julieéàèùò&~#@œæŒÆ,female,test@yopmail.com,0102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur
+131,carac_speciaux,123,DURANTéàèùòœæŒÆ,,JulieéàèùòœæŒÆ,female,test@yopmail.com,0102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur
 132,sans_prenom,123,MARTIN,,,female,test@yopmail.com,0102030405,14/06/1972,44100,99100,France,Nantes,44317,20 avenue de Ségur


### PR DESCRIPTION
Ajout de nouveau cas de test non présent actuellement :
1 personne née à Wallis-et-Futuna, 1 personne sans prénom, 1 personne dont le nom et prénom contiennent des caractères spéciaux.
Ces cas de tests sont nécessaire aux tests d'integration de FranceConnect par le casier Judiciaire National

Toutes les données sont fictives
Ces cas de test répondent a des traitement métier specifique au Casier Judiciaire (personne né à Wallis-et-Futuna, sans prénom, etc...).

Nous essayons de limiter au maximum l'ajout d'identités dans le fichier [database.csv](database.csv) pour réduire les coûts de maintenance et limiter les risques de non conformité au RGPD.

Si vous avez modifié ce fichier, pouvez vous nous préciser ce qui vous a manqué dans les identités déjà présentes dans le fichier et en quoi vos identités résolvent le problème ?
